### PR TITLE
Add more query operations

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -273,6 +273,18 @@ myEntity
 
 This method will throw an error on the attempt of updating a component that has not been added before.
 
+### `entity.put(CC: ComponentConstructor, value?: object): Entity`
+
+This method adds the given component if it has not been added before, otherwise it updates it.
+
+**EXAMPLE**
+```typescript
+myEntity
+    .put(My3DPositionComponent, {
+        x: 64
+    });
+```
+
 ### `entity.build(builderFn: entity => entity): Component`
 
 This method applies the given builder function to the entity. It can be used to encapsulate construction logic for specific entities.

--- a/docs/API.md
+++ b/docs/API.md
@@ -402,6 +402,10 @@ class MovementSystem extends System {
 }
 ```
 
+When a system is registered to a scene, nopun-ecs takes care of compiling the here defined queries, so that their results can be accessed during execution of the system.
+
+#### Filter Function `Not(...terms: (ComponentConstruct | FilterFn)[])`
+
 Negations can be expressed via the `Not`-function.
 
 **EXAMPLE:**
@@ -416,7 +420,43 @@ class MovementSystem extends System {
 }
 ```
 
-When a system is registered to a scene, nopun-ecs takes care of compiling the here defined queries, so that their results can be accessed during execution of the system.
+#### Filter Function `And(...terms: (ComponentConstruct | FilterFn)[])`
+
+Conjunctions can be expressed via the `And`-function.
+
+**EXAMPLE:**
+```typescript
+import { System, And, Not } from "nopun-ecs";
+
+class MovementSystem extends System {
+    static queries = {
+        movables: [And(Position, Velocity)],
+        immovables: [And(Position, Not(Velocity))]
+    };
+}
+```
+
+*Hint: `And` is automatically applied to the outer array of each query.*
+
+#### Filter Function `Or(...terms: (ComponentConstruct | FilterFn)[])`
+
+Disjunctions can be expressed via the `Or`-function.
+
+**EXAMPLE:**
+```typescript
+import { System, Or } from "nopun-ecs";
+
+class CollisionSystem extends System {
+    static queries = {
+        npcs: [CollisionShape, Or(Friend, Enemy)],
+        player: [CollisionShape, Player]
+    };
+}
+```
+
+#### Filter Function `Xor(...terms: (ComponentConstruct | FilterFn)[])`
+
+Exclusive disjunctions can be expressed via the `Xor`-function. This is in here more for completeness - I actually struggle to come up with a plausible example for its use. If you have one, please let me know :)
 
 ### `(system) this.initialize(): void`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -323,6 +323,17 @@ if (myEntity.has(My3DPositionComponent)) {
 }
 ```
 
+### `entity.take(...CCs: ComponentConstructor[]): Generator<C[]>`
+
+This method will check for the existence of multiple components and will only yield a result, if all components are present.
+
+**EXAMPLE:**
+```typescript
+for (const [position, weight] of myEntity.take(My3DPositionComponent, Weight)) {
+    console.log('This entity is affected by gravity in 3D space.');
+}
+```
+
 ### `entity.remove(CC: ComponentConstructor): Entity`
 
 An existing component can be removed from an entity at any point during runtime.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Scene } from "./internal/Scene";
 export { System } from "./internal/System";
 export type { Entity } from "./internal/Entity";
-export { Not } from "./internal/Filter";
+export { Not, And, Or, Xor } from "./internal/Filter";

--- a/src/internal/Entity.spec.ts
+++ b/src/internal/Entity.spec.ts
@@ -266,4 +266,67 @@ describe('Entity', () => {
 		expect(entity.has(Foo)).toBe(true);
 		expect(entity.get(Foo).value).toBe('bar');
 	});
+
+	it('provides a method to manipulate components only if they are set', () => {
+		const updateQueue = { queueForUpdate: jest.fn() }
+		const scene = new Scene();
+		const entity = new Entity(scene, updateQueue);
+		let counter = 0;
+
+		class Foo { value: string = 'initial Foo' }
+
+		for (const [foo] of entity.take(Foo)) {
+			foo.value = 'next Foo';
+			counter++;
+		}
+
+		expect(counter).toBe(0);
+
+		entity.add(Foo);
+		for (const [foo] of entity.take(Foo)) {
+			foo.value = 'next Foo';
+			counter++;
+		}
+
+		expect(counter).toBe(1);
+		expect(entity.get(Foo).value).toBe('next Foo');
+	});
+
+	it('provides a method to manipulate multiple components only if all of them are set', () => {
+		const updateQueue = { queueForUpdate: jest.fn() }
+		const scene = new Scene();
+		const entity = new Entity(scene, updateQueue);
+		let counter = 0;
+
+		class Foo { value: string = 'initial Foo' }
+		class Bar { value: string = 'initial Bar' }
+
+		for (const [foo, bar] of entity.take(Foo, Bar)) {
+			foo.value = 'next Foo';
+			bar.value = 'next Bar';
+			counter++;
+		}
+
+		expect(counter).toBe(0);
+
+		entity.add(Foo);
+		for (const [foo, bar] of entity.take(Foo, Bar)) {
+			foo.value = 'next Foo';
+			bar.value = 'next Bar';
+			counter++;
+		}
+
+		expect(counter).toBe(0);
+
+		entity.add(Bar);
+		for (const [foo, bar] of entity.take(Foo, Bar)) {
+			foo.value = 'next Foo';
+			bar.value = 'next Bar';
+			counter++;
+		}
+
+		expect(counter).toBe(1);
+		expect(entity.get(Foo).value).toBe('next Foo');
+		expect(entity.get(Bar).value).toBe('next Bar');
+	});
 });

--- a/src/internal/Entity.spec.ts
+++ b/src/internal/Entity.spec.ts
@@ -233,4 +233,37 @@ describe('Entity', () => {
 		expect(makeSomething).toHaveBeenCalledTimes(1);
 		expect(makeSomething).toHaveBeenLastCalledWith(entity);
 	});
+
+	it('provides a method to add or update components dependending on whether they are already set', () => {
+		const updateQueue = { queueForUpdate: jest.fn() }
+		const scene = new Scene();
+		const entity = new Entity(scene, updateQueue);
+
+		class Foo { value: string = 'foo' }
+
+		expect(entity.has(Foo)).toBe(false);
+
+		entity.put(Foo);
+		expect(entity.has(Foo)).toBe(true);
+		expect(entity.get(Foo).value).toBe('foo');
+
+		entity.remove(Foo);
+		expect(entity.has(Foo)).toBe(false);
+
+		entity.add(Foo);
+		expect(entity.has(Foo)).toBe(true);
+		expect(entity.get(Foo).value).toBe('foo');
+
+		entity.put(Foo);
+		expect(entity.has(Foo)).toBe(true);
+		expect(entity.get(Foo).value).toBe('foo');
+
+		entity.put(Foo, { value: 'bar' });
+		expect(entity.has(Foo)).toBe(true);
+		expect(entity.get(Foo).value).toBe('bar');
+
+		entity.put(Foo);
+		expect(entity.has(Foo)).toBe(true);
+		expect(entity.get(Foo).value).toBe('bar');
+	});
 });

--- a/src/internal/Entity.ts
+++ b/src/internal/Entity.ts
@@ -40,6 +40,16 @@ export class Entity {
 		return this;
 	}
 
+	public put<C extends Component>(
+		CC: ComponentConstructor<C>,
+		overwriteValue: Partial<C> = {}
+	): this {
+		if (this.componentsStore.has(CC))
+			return this.update(CC, overwriteValue);
+
+		return this.add(CC, overwriteValue);
+	}
+
 	public build(builderFn: (entity: this) => this): this {
 		return builderFn(this);
 	}

--- a/src/internal/Entity.ts
+++ b/src/internal/Entity.ts
@@ -7,6 +7,8 @@ export interface IUpdateQueue {
 
 export class Entity {
 	private readonly componentsStore = new Map<ComponentConstructor, Component>();
+	private readonly componentsStoreHas = this.componentsStore.has.bind(this.componentsStore);
+	private readonly componentsStoreGet = this.componentsStore.get.bind(this.componentsStore);
 	constructor(
 		public readonly scene: Scene,
 		private readonly updateQueue: IUpdateQueue
@@ -72,6 +74,11 @@ export class Entity {
 			throw new AttemptToGetUnassignedComponent(this, CC);
 
 		return this.componentsStore.get(CC) as C;
+	}
+
+	public *take<C extends Component>(...CCs: ComponentConstructor<C>[]): Generator<C[]> {
+		if (CCs.every(this.componentsStoreHas))
+			yield CCs.map(this.componentsStoreGet) as C[];
 	}
 
 	private readonly childrenStore = new Set<Entity>();

--- a/src/internal/Filter.ts
+++ b/src/internal/Filter.ts
@@ -1,11 +1,77 @@
 import { ComponentConstructor } from "./Component";
+import { Entity } from "./Entity";
 
-export class Negation {
-    constructor(public readonly subject: ComponentConstructor) {}
+export type Node =
+	| ComponentConstructor
+	| Filter;
+
+interface FilterFn {
+	(entity: Entity): boolean
 }
 
-export type Filter = (ComponentConstructor | Negation)[];
+export class Filter {
+	private constructor(
+		public readonly filterFn: FilterFn
+	) {}
 
-export function Not(cc: ComponentConstructor) {
-    return new Negation(cc);
+	public static from(filterFn: FilterFn): Filter {
+		return new Filter(filterFn);
+	}
+}
+
+function applyFilter(entity: Entity, node: Node): boolean {
+	return node instanceof Filter ? node.filterFn(entity) : entity.has(node);
+}
+
+export function Not(...nodes: Node[]) {
+    return Filter.from(entity => {
+		for (const node of nodes) {
+			if (applyFilter(entity, node)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+}
+
+export function And(...nodes: Node[]) {
+	return Filter.from(entity => {
+		for (const node of nodes) {
+			if (!applyFilter(entity, node)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+}
+
+export function Or(...nodes: Node[]) {
+	return Filter.from(entity => {
+		for (const node of nodes) {
+			if (applyFilter(entity, node)) {
+				return true;
+			}
+		}
+
+		return false;
+	});
+}
+
+export function Xor(...nodes: Node[]) {
+	return Filter.from(entity => {
+		let match = false;
+		for (const node of nodes) {
+			if (applyFilter(entity, node)) {
+				if (match) {
+					return false;
+				} else {
+					match = true;
+				}
+			}
+		}
+
+		return match;
+	});
 }

--- a/src/internal/Query.spec.ts
+++ b/src/internal/Query.spec.ts
@@ -1,6 +1,6 @@
 import { Entity } from "./Entity";
 import { Query } from "./Query";
-import { Not } from "./Filter";
+import { And, Not, Or, Xor } from "./Filter";
 import { Scene } from "./Scene";
 
 describe('Query > Writer', () => {
@@ -456,5 +456,71 @@ describe('Query > Filter', () => {
 		expect(query.matches(entity2)).toBe(false);
 		expect(query.matches(entity3)).toBe(false);
 		expect(query.matches(entity4)).toBe(false);
+	});
+
+	it('filters by conjunction', () => {
+		class DummyComponent1 { property = 'foo' }
+		class DummyComponent2 { property = 'bar' }
+		class DummyComponent3 { property = 'baz' }
+		const scene = new Scene();
+		const entity1 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity2 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity3 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity4 = new Entity(scene, { queueForUpdate: () => {} });
+		const query = new Query([And(DummyComponent1, DummyComponent3)]);
+
+		entity1.add(DummyComponent1).add(DummyComponent2);
+		entity2.add(DummyComponent1).add(DummyComponent3);
+		entity3.add(DummyComponent2);
+		entity4.add(DummyComponent1).add(DummyComponent2).add(DummyComponent3);
+
+		expect(query.matches(entity1)).toBe(false);
+		expect(query.matches(entity2)).toBe(true);
+		expect(query.matches(entity3)).toBe(false);
+		expect(query.matches(entity4)).toBe(true);
+	});
+
+	it('filters by disjunction', () => {
+		class DummyComponent1 { property = 'foo' }
+		class DummyComponent2 { property = 'bar' }
+		class DummyComponent3 { property = 'baz' }
+		const scene = new Scene();
+		const entity1 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity2 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity3 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity4 = new Entity(scene, { queueForUpdate: () => {} });
+		const query = new Query([Or(DummyComponent1, DummyComponent3)]);
+
+		entity1.add(DummyComponent1).add(DummyComponent2);
+		entity2.add(DummyComponent1).add(DummyComponent3);
+		entity3.add(DummyComponent2);
+		entity4.add(DummyComponent1).add(DummyComponent2).add(DummyComponent3);
+
+		expect(query.matches(entity1)).toBe(true);
+		expect(query.matches(entity2)).toBe(true);
+		expect(query.matches(entity3)).toBe(false);
+		expect(query.matches(entity4)).toBe(true);
+	});
+
+	it('filters by difference', () => {
+		class DummyComponent1 { property = 'foo' }
+		class DummyComponent2 { property = 'bar' }
+		class DummyComponent3 { property = 'baz' }
+		const scene = new Scene();
+		const entity1 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity2 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity3 = new Entity(scene, { queueForUpdate: () => {} });
+		const entity4 = new Entity(scene, { queueForUpdate: () => {} });
+		const query = new Query([Xor(DummyComponent1, DummyComponent3)]);
+
+		entity1.add(DummyComponent1).add(DummyComponent2);
+		entity2.add(DummyComponent1).add(DummyComponent3);
+		entity3.add(DummyComponent2);
+		entity4.add(DummyComponent2).add(DummyComponent3);
+
+		expect(query.matches(entity1)).toBe(true);
+		expect(query.matches(entity2)).toBe(false);
+		expect(query.matches(entity3)).toBe(false);
+		expect(query.matches(entity4)).toBe(true);
 	});
 });

--- a/src/internal/Query.ts
+++ b/src/internal/Query.ts
@@ -1,4 +1,4 @@
-import { Filter, Negation } from "./Filter";
+import { And, Filter, Node } from "./Filter";
 import { Entity } from "./Entity";
 
 export interface IQueryWriter {
@@ -22,19 +22,14 @@ export class Query {
 	private readonly added = new Set<Entity>();
 	private readonly removed = new Set<Entity>();
 	private readonly unchanged = new Set<Entity>();
+	private readonly filter: Filter;
 
-	constructor(
-		private readonly filter: Filter
-	) {}
+	constructor(nodes: Node[]) {
+		this.filter = And(...nodes);
+	}
 
 	public matches(entity: Entity): boolean {
-		return this.filter.every(f => {
-			if (f instanceof Negation) {
-				return !entity.has(f.subject);
-			} else {
-				return entity.has(f);
-			}
-		});
+		return this.filter.filterFn(entity);
 	}
 
 	public readonly writer: IQueryWriter = (() => {

--- a/src/internal/System.ts
+++ b/src/internal/System.ts
@@ -1,10 +1,10 @@
 import { Scene } from "./Scene";
-import { Filter } from "./Filter";
+import { Node } from "./Filter";
 import { Query, IQueryReader } from "./Query";
 
 export abstract class System {
 	static queries: {
-		[key: string]: Filter
+		[key: string]: Node[]
 	} = {};
 
 	public constructor(
@@ -27,7 +27,7 @@ export type SystemConstructor<S extends System = any> = {
 		}
 	): S
 	queries: {
-		[key: string]: Filter
+		[key: string]: Node[]
 	}
 }
 

--- a/test/ComplexQueries.And.test.ts
+++ b/test/ComplexQueries.And.test.ts
@@ -1,0 +1,159 @@
+import { Scene, System, And, Not } from '../src';
+
+describe('Complex Queries: And', () => {
+	class Foo {
+		value: string = 'initial Foo'
+	}
+
+	class Bar {
+		value: string = 'initial Bar'
+	}
+
+	class Baz {
+		value: string = 'initial Baz'
+	}
+
+	class MySystem extends System {
+		static queries = {
+			withFoo: [And(Foo)],
+			withOnlyBar: [And(Bar, Not(Foo))],
+			withFooAndBar: [And(Foo, Bar)],
+			withNeitherFooNorBar: [And(Not(Foo), Not(Bar))]
+		}
+
+		execute() {
+			// Added
+			for (const entity of this.queries.withFoo.added) {
+				entity.get(Foo).value = 'Foo was added';
+			}
+
+			for (const entity of this.queries.withOnlyBar.added) {
+				entity.get(Bar).value = 'Bar was added';
+			}
+
+			for (const entity of this.queries.withFooAndBar.added) {
+				entity.get(Foo).value = 'Foo and Bar were added';
+				entity.get(Bar).value = 'Foo and Bar were added';
+			}
+
+			// Unchanged
+			for (const entity of this.queries.withFoo.unchanged) {
+				entity.get(Foo).value = 'Foo was unchanged';
+			}
+
+			for (const entity of this.queries.withOnlyBar.unchanged) {
+				entity.get(Bar).value = 'Bar was unchanged';
+			}
+
+			for (const entity of this.queries.withFooAndBar.unchanged) {
+				entity.get(Foo).value = 'Foo and Bar were unchanged';
+				entity.get(Bar).value = 'Foo and Bar were unchanged';
+			}
+
+			// Removed
+			for (const entity of this.queries.withFoo.removed) {
+				entity.add(Baz, { value: 'Foo was removed' });
+			}
+
+			for (const entity of this.queries.withOnlyBar.removed) {
+				entity.put(Baz, { value: 'Bar was removed' });
+			}
+
+			for (const entity of this.queries.withNeitherFooNorBar.removed) {
+				entity.get(Baz).value = 'A Foo or a Bar was added';
+			}
+		}
+	}
+
+	const scene = new Scene();
+
+	scene.systems.register(MySystem);
+
+	const hasOnlyFoo = scene.entities.create().add(Foo);
+	const hasOnlyBar = scene.entities.create().add(Bar);
+	const hasFooAndBar = scene.entities.create().add(Foo).add(Bar);
+	const hasNeitherFooNorBar = scene.entities.create().add(Baz);
+
+	it('recognizes added entities', () => {
+		scene.execute(1);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was added');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was added');
+
+		expect(hasFooAndBar.get(Foo).value).toBe('Foo and Bar were added');
+		expect(hasFooAndBar.get(Bar).value).toBe('Foo and Bar were added');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes unchanged entities', () => {
+		scene.execute(2);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.get(Foo).value).toBe('Foo and Bar were unchanged');
+		expect(hasFooAndBar.get(Bar).value).toBe('Foo and Bar were unchanged');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes removed entities', () => {
+		hasFooAndBar.remove(Foo);
+		scene.execute(3);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.get(Bar).value).toBe('Bar was added');
+		expect(hasFooAndBar.get(Baz).value).toBe('Foo was removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+
+		hasFooAndBar.remove(Bar);
+		scene.execute(4);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.get(Baz).value).toBe('Bar was removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+
+		hasOnlyFoo.remove(Foo);
+		scene.execute(5);
+
+		expect(hasOnlyFoo.has(Foo)).toBe(false);
+		expect(hasOnlyFoo.get(Baz).value).toBe('Foo was removed');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.get(Baz).value).toBe('Bar was removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+
+		hasOnlyBar.remove(Bar);
+		scene.execute(6);
+
+		expect(hasOnlyFoo.has(Foo)).toBe(false);
+		expect(hasOnlyFoo.get(Baz).value).toBe('Foo was removed');
+		expect(hasOnlyBar.has(Bar)).toBe(false);
+		expect(hasOnlyBar.get(Baz).value).toBe('Bar was removed');
+
+		expect(hasFooAndBar.get(Baz).value).toBe('Bar was removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+
+		hasNeitherFooNorBar.add(Foo);
+		scene.execute(7);
+
+		expect(hasOnlyFoo.has(Foo)).toBe(false);
+		expect(hasOnlyFoo.get(Baz).value).toBe('Foo was removed');
+		expect(hasOnlyBar.has(Bar)).toBe(false);
+		expect(hasOnlyBar.get(Baz).value).toBe('Bar was removed');
+
+		expect(hasFooAndBar.get(Baz).value).toBe('Bar was removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('A Foo or a Bar was added');
+		expect(hasNeitherFooNorBar.get(Foo).value).toBe('Foo was added');
+	});
+});

--- a/test/ComplexQueries.Everything.test.ts
+++ b/test/ComplexQueries.Everything.test.ts
@@ -1,0 +1,178 @@
+import { Scene, System, And, Or, Xor, Not } from '../src';
+
+describe('Complex Queries: Everything', () => {
+	class Foo {
+		value: string = 'initial Foo'
+	}
+
+	class Bar {
+		value: string = 'initial Bar'
+	}
+
+	class Baz {
+		value: string = 'initial Baz'
+	}
+
+	class Qux {
+		value: string = 'initial Qux'
+	}
+
+	class Removed {
+	}
+
+	class MySystem extends System {
+		static queries = {
+			matches: [Xor(And(Foo, Bar), And(Foo, Baz), Not(Or(Foo, Bar, Baz)), Not(Baz))]
+		}
+
+		execute() {
+			for (const entity of this.queries.matches.added) {
+				for (const [foo] of entity.take(Foo)) {
+					foo.value = 'Foo was added';
+				}
+				for (const [bar] of entity.take(Bar)) {
+					bar.value = 'Bar was added';
+				}
+				for (const [baz] of entity.take(Baz)) {
+					baz.value = 'Baz was added';
+				}
+				for (const [qux] of entity.take(Qux)) {
+					qux.value = 'Qux was added';
+				}
+			}
+
+			for (const entity of this.queries.matches.unchanged) {
+				for (const [foo] of entity.take(Foo)) {
+					foo.value = 'Foo was unchanged';
+				}
+				for (const [bar] of entity.take(Bar)) {
+					bar.value = 'Bar was unchanged';
+				}
+				for (const [baz] of entity.take(Baz)) {
+					baz.value = 'Baz was unchanged';
+				}
+				for (const [qux] of entity.take(Qux)) {
+					qux.value = 'Qux was unchanged';
+				}
+			}
+
+			for (const entity of this.queries.matches.removed) {
+				entity.add(Removed);
+			}
+		}
+	}
+
+	const scene = new Scene();
+
+	scene.systems.register(MySystem);
+
+	const hasOnlyFoo = scene.entities.create().add(Foo);
+	const hasOnlyBar = scene.entities.create().add(Bar);
+	const hasOnlyBaz = scene.entities.create().add(Baz);
+	const hasOnlyQux = scene.entities.create().add(Qux);
+	const hasFooAndBar = scene.entities.create().add(Foo).add(Bar);
+	const hasFooAndBaz = scene.entities.create().add(Foo).add(Baz);
+	const hasFooAndQux = scene.entities.create().add(Foo).add(Qux);
+	const hasBarAndBaz = scene.entities.create().add(Bar).add(Baz);
+	const hasFooAndBarAndBaz = scene.entities.create().add(Foo).add(Bar).add(Baz);
+
+	it('recognizes added entities', () => {
+		scene.execute(1);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was added'); // matches only Not(Baz)
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was added'); // matches only Not(Baz)
+		expect(hasOnlyBaz.get(Baz).value).toBe('initial Baz'); // matches nothing
+		expect(hasOnlyQux.get(Qux).value).toBe('initial Qux'); // matches Not(Or(Foo, Bar, Baz)) as well as Not(Baz)
+
+		expect(hasFooAndBar.get(Foo).value).toBe('initial Foo'); // matches And(Foo, Bar) as well as Not(Baz)
+		expect(hasFooAndBar.get(Bar).value).toBe('initial Bar');
+
+		expect(hasFooAndBaz.get(Foo).value).toBe('Foo was added'); // matches And(Foo, Baz)
+		expect(hasFooAndBaz.get(Baz).value).toBe('Baz was added');
+
+		expect(hasFooAndQux.get(Foo).value).toBe('Foo was added'); // matches Not(Baz)
+		expect(hasFooAndQux.get(Qux).value).toBe('Qux was added');
+
+		expect(hasBarAndBaz.get(Bar).value).toBe('initial Bar'); // matches nothing
+		expect(hasBarAndBaz.get(Baz).value).toBe('initial Baz');
+
+		expect(hasFooAndBarAndBaz.get(Foo).value).toBe('initial Foo'); // matches And(Foo, Bar) as well as And(Foo, Baz)
+		expect(hasFooAndBarAndBaz.get(Bar).value).toBe('initial Bar');
+		expect(hasFooAndBarAndBaz.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes unchanged entities', () => {
+		scene.execute(2);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged'); // matches only Not(Baz)
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged'); // matches only Not(Baz)
+		expect(hasOnlyBaz.get(Baz).value).toBe('initial Baz'); // matches nothing
+		expect(hasOnlyQux.get(Qux).value).toBe('initial Qux'); // matches Not(Or(Foo, Bar, Baz)) as well as Not(Baz)
+
+		expect(hasFooAndBar.get(Foo).value).toBe('initial Foo'); // matches And(Foo, Bar) as well as Not(Baz)
+		expect(hasFooAndBar.get(Bar).value).toBe('initial Bar');
+
+		expect(hasFooAndBaz.get(Foo).value).toBe('Foo was unchanged'); // matches only And(Foo, Baz)
+		expect(hasFooAndBaz.get(Baz).value).toBe('Baz was unchanged');
+
+		expect(hasFooAndQux.get(Foo).value).toBe('Foo was unchanged'); // matches only Not(Baz)
+		expect(hasFooAndQux.get(Qux).value).toBe('Qux was unchanged');
+
+		expect(hasBarAndBaz.get(Bar).value).toBe('initial Bar'); // matches nothing
+		expect(hasBarAndBaz.get(Baz).value).toBe('initial Baz');
+
+		expect(hasFooAndBarAndBaz.get(Foo).value).toBe('initial Foo'); // matches And(Foo, Bar) as well as And(Foo, Baz)
+		expect(hasFooAndBarAndBaz.get(Bar).value).toBe('initial Bar');
+		expect(hasFooAndBarAndBaz.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('does nothing if a non-matching entity loses components and still does not match the query condition', () => {
+		hasBarAndBaz.remove(Bar);
+		scene.execute(3);
+
+		expect(hasBarAndBaz.has(Bar)).toBe(false);
+		expect(hasBarAndBaz.get(Baz).value).toBe('initial Baz'); // matches nothing
+	});
+
+	it('does noting if a non-matching entity gains components and still does not match the query condition', () => {
+		hasFooAndBar.add(Baz);
+		scene.execute(4);
+
+		expect(hasFooAndBar.get(Foo).value).toBe('initial Foo'); // matches And(Foo, Bar) as well as And(Foo, Baz)
+		expect(hasFooAndBar.get(Bar).value).toBe('initial Bar');
+		expect(hasFooAndBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes if a component loses enough components to not match the query condition anymore', () => {
+		hasFooAndBaz.remove(Foo);
+		scene.execute(5);
+
+		expect(hasFooAndBaz.has(Foo)).toBe(false);
+		expect(hasFooAndBaz.get(Baz).value).toBe('Baz was unchanged');
+		expect(hasFooAndBaz.has(Removed)).toBe(true);
+	});
+
+	it('recognizes if a component gains enough components to not match the query condition anymore', () => {
+		hasOnlyBar.remove(Bar);
+		scene.execute(6);
+
+		expect(hasOnlyBar.has(Bar)).toBe(false);
+		expect(hasOnlyBar.has(Removed)).toBe(true);
+	});
+
+	it('recognizes if a component gains enough components to now match the query condition', () => {
+		hasOnlyBaz.add(Foo);
+		scene.execute(7);
+
+		expect(hasOnlyBaz.get(Foo).value).toBe('Foo was added');
+		expect(hasOnlyBaz.get(Baz).value).toBe('Baz was added');
+	});
+
+	it('recognizes if a component loses enough components to now match the query condition', () => {
+		hasFooAndBarAndBaz.remove(Bar);
+		scene.execute(8);
+
+		expect(hasFooAndBarAndBaz.get(Foo).value).toBe('Foo was added');
+		expect(hasFooAndBarAndBaz.get(Baz).value).toBe('Baz was added');
+	});
+});

--- a/test/ComplexQueries.Or.test.ts
+++ b/test/ComplexQueries.Or.test.ts
@@ -1,0 +1,145 @@
+import { Scene, System, Or, Not } from '../src';
+
+describe('Complex Queries: Or', () => {
+	class Foo {
+		value: string = 'initial Foo'
+	}
+
+	class Bar {
+		value: string = 'initial Bar'
+	}
+
+	class Baz {
+		value: string = 'initial Baz'
+	}
+
+	class MySystem extends System {
+		static queries = {
+			withFooOrBar: [Or(Foo, Bar)],
+			WithNeitherFooNorBar: [Not(Or(Foo, Bar))]
+		}
+
+		execute() {
+			for (const entity of this.queries.withFooOrBar.added) {
+				for (const [foo] of entity.take(Foo)) {
+					foo.value = 'Foo was added';
+				}
+				for (const [bar] of entity.take(Bar)) {
+					bar.value = 'Bar was added';
+				}
+			}
+
+			for (const entity of this.queries.withFooOrBar.unchanged) {
+				for (const [foo] of entity.take(Foo)) {
+					foo.value = 'Foo was unchanged';
+				}
+				for (const [bar] of entity.take(Bar)) {
+					bar.value = 'Bar was unchanged';
+				}
+			}
+
+			for (const entity of this.queries.withFooOrBar.removed) {
+				entity.add(Baz, { value: 'Foo and Bar were removed' });
+			}
+
+			for (const entity of this.queries.WithNeitherFooNorBar.removed) {
+				entity.update(Baz, { value: 'Foo or Bar was added' });
+			}
+		}
+	}
+
+	const scene = new Scene();
+
+	scene.systems.register(MySystem);
+
+	const hasOnlyFoo = scene.entities.create().add(Foo);
+	const hasOnlyBar = scene.entities.create().add(Bar);
+	const hasFooAndBar = scene.entities.create().add(Foo).add(Bar);
+	const hasNeitherFooNorBar = scene.entities.create().add(Baz);
+
+	it('recognizes added entities', () => {
+		scene.execute(1);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was added');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was added');
+
+		expect(hasFooAndBar.get(Foo).value).toBe('Foo was added');
+		expect(hasFooAndBar.get(Bar).value).toBe('Bar was added');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes unchanged entities', () => {
+		scene.execute(3);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasFooAndBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('does not react when an entity lost a compoenent but still matches the disjunction', () => {
+		hasFooAndBar.remove(Bar);
+		scene.execute(4);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasFooAndBar.has(Bar)).toBe(false);
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes when an entity lost enough components to not match the disjunction anymore', () => {
+		hasFooAndBar.remove(Foo);
+		scene.execute(5);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.has(Foo)).toBe(false);
+		expect(hasFooAndBar.has(Bar)).toBe(false);
+		expect(hasFooAndBar.get(Baz).value).toBe('Foo and Bar were removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+
+		hasOnlyFoo.remove(Foo);
+		scene.execute(6);
+
+		expect(hasOnlyFoo.has(Foo)).toBe(false);
+		expect(hasOnlyFoo.get(Baz).value).toBe('Foo and Bar were removed');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.has(Foo)).toBe(false);
+		expect(hasFooAndBar.has(Bar)).toBe(false);
+		expect(hasFooAndBar.get(Baz).value).toBe('Foo and Bar were removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+
+		hasOnlyBar.remove(Bar);
+		scene.execute(7);
+
+		expect(hasOnlyFoo.has(Foo)).toBe(false);
+		expect(hasOnlyFoo.get(Baz).value).toBe('Foo and Bar were removed');
+		expect(hasOnlyBar.has(Bar)).toBe(false);
+		expect(hasOnlyBar.get(Baz).value).toBe('Foo and Bar were removed');
+
+		expect(hasFooAndBar.has(Foo)).toBe(false);
+		expect(hasFooAndBar.has(Bar)).toBe(false);
+		expect(hasFooAndBar.get(Baz).value).toBe('Foo and Bar were removed');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes when an entity gained enough components to match the disjunction.', () => {
+		hasNeitherFooNorBar.add(Foo);
+		scene.execute(8);
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('Foo or Bar was added');
+		expect(hasNeitherFooNorBar.get(Foo).value).toBe('Foo was added');
+	});
+});

--- a/test/ComplexQueries.Xor.test.ts
+++ b/test/ComplexQueries.Xor.test.ts
@@ -1,0 +1,109 @@
+import { Scene, System, Xor, Not } from '../src';
+
+describe('Complex Queries: Xor', () => {
+	class Foo {
+		value: string = 'initial Foo'
+	}
+
+	class Bar {
+		value: string = 'initial Bar'
+	}
+
+	class Baz {
+		value: string = 'initial Baz'
+	}
+
+	class MySystem extends System {
+		static queries = {
+			withEitherFooOrBar: [Xor(Foo, Bar)],
+			withBothOrNone: [Not(Xor(Foo, Bar))]
+		}
+
+		execute() {
+			for (const entity of this.queries.withEitherFooOrBar.added) {
+				for (const [foo] of entity.take(Foo)) {
+					foo.value = 'Foo was added';
+				}
+				for (const [bar] of entity.take(Bar)) {
+					bar.value = 'Bar was added';
+				}
+			}
+
+			for (const entity of this.queries.withEitherFooOrBar.unchanged) {
+				for (const [foo] of entity.take(Foo)) {
+					foo.value = 'Foo was unchanged';
+				}
+				for (const [bar] of entity.take(Bar)) {
+					bar.value = 'Bar was unchanged';
+				}
+			}
+
+			for (const entity of this.queries.withEitherFooOrBar.removed) {
+				if (entity.has(Foo) || entity.has(Bar)) {
+					entity.add(Baz, { value: 'Foo or Bar was added' });
+				} else {
+					entity.add(Baz, { value: 'Foo or Bar was removed' });
+				}
+			}
+		}
+	}
+
+	const scene = new Scene();
+
+	scene.systems.register(MySystem);
+
+	const hasOnlyFoo = scene.entities.create().add(Foo);
+	const hasOnlyBar = scene.entities.create().add(Bar);
+	const hasFooAndBar = scene.entities.create().add(Foo).add(Bar);
+	const hasNeitherFooNorBar = scene.entities.create().add(Baz);
+
+	it('recognizes added entities', () => {
+		scene.execute(1);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was added');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was added');
+
+		expect(hasFooAndBar.get(Foo).value).toBe('initial Foo');
+		expect(hasFooAndBar.get(Bar).value).toBe('initial Bar');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes unchanged entities', () => {
+		scene.execute(3);
+
+		expect(hasOnlyFoo.get(Foo).value).toBe('Foo was unchanged');
+		expect(hasOnlyBar.get(Bar).value).toBe('Bar was unchanged');
+
+		expect(hasFooAndBar.get(Foo).value).toBe('initial Foo');
+		expect(hasFooAndBar.get(Bar).value).toBe('initial Bar');
+
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+
+	it('recognizes when an entity lost enough components to not match the exclusive disjunction anymore', () => {
+		hasOnlyFoo.remove(Foo);
+		scene.execute(4);
+
+		expect(hasOnlyFoo.has(Foo)).toBe(false);
+		expect(hasOnlyFoo.get(Baz).value).toBe('Foo or Bar was removed');
+	});
+
+	it('recognizes when an entity gained enough components to not match the exclusive disjunction anymore', () => {
+		hasOnlyBar.add(Foo);
+		scene.execute(4);
+
+		expect(hasOnlyBar.has(Foo)).toBe(true);
+		expect(hasOnlyBar.get(Foo).value).toBe('initial Foo');
+		expect(hasOnlyBar.get(Baz).value).toBe('Foo or Bar was added');
+	});
+
+	it('recognizes when an entity gained enough components to match the exclusive disjunctions', () => {
+		hasNeitherFooNorBar.add(Bar);
+		scene.execute(4);
+
+		expect(hasNeitherFooNorBar.has(Bar)).toBe(true);
+		expect(hasNeitherFooNorBar.get(Bar).value).toBe('Bar was added');
+		expect(hasNeitherFooNorBar.get(Baz).value).toBe('initial Baz');
+	});
+});

--- a/test/SimpleQueries.test.ts
+++ b/test/SimpleQueries.test.ts
@@ -59,11 +59,7 @@ describe('Simple Queries', () => {
 			}
 
 			for (const entity of this.queries.withComponentsFooAndBar.removed) {
-				if (entity.has(Baz)) {
-					entity.update(Baz, {value: 'Foo and Bar were removed'});
-				} else {
-					entity.add(Baz, {value: 'Foo and Bar were removed'});
-				}
+				entity.put(Baz, {value: 'Foo and Bar were removed'});
 			}
 		}
 	}


### PR DESCRIPTION
This adds more query operations, namely:

- `And(...)`
- `Or(...)`
- `Not(...)` - This one existed before, but now accepts multiple arguments
- `Xor(...)`

## TODOs

- [x] Add more tests
- [x] Add documentation for new operations

resolves #9 